### PR TITLE
Fail if trigger in mid sentence

### DIFF
--- a/plugins/plugin_slack.php
+++ b/plugins/plugin_slack.php
@@ -9,18 +9,17 @@
 	# outgoing webhook data to what's required for restful-frotz
 	#
 	function handler_input(&$params){
-
-		$command = str_replace($params['trigger_word'], "", $params['text']);
-		if (substr($command, 0, 1) != " "){
+		
+		$command = substr($params['text'], strlen($params['trigger_word'] + ' '));
+		# Command is the trigger + space removed from whole input
+		if (strpos($params['text'], $params['trigger_word']) != '0' ){
 			#
-			# The trigger was not followed by a space,
-			# so they might have just started a sentance with
-			# the trigger word, so bail with no output.
-			#
+			# The input didn't start with the trigger word, so
+			# bail with no output
 			die;
 		}
 
-		$params['command'] = substr($command, 1);
+		$params['command'] = $command;
 	}
 
 


### PR DESCRIPTION
A short trigger word like 'z' (which we have at MUO's slack) may be used elsewhere in the sentence (Example, in the 'maze' parts of the game). Fixing code where it stripped out all occurrences of trigger word incorrectly.

Forgive any mistakes in the code, am not a PHP dev.
